### PR TITLE
Fix links in header and footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
                 <h3 class="inline push--right">Our services:</h3>
                 <ul class="nav-intro">
                   <li class="soft--right"><a class="" href="https://www.exportingisgreat.gov.uk/opportunities" title="Exporting opportunities">Exporting opportunities</a></li>
-                  <li class="soft--right"><a class="" href="http://find-a-buyer.export.great.gov.uk/" title="Find a buyer">Find a buyer</a></li>
-                  <li class="soft--right"><a class="" href="https://www.exportingisgreat.gov.uk/opportunities" title="Selling online overseas">Selling online overseas</a></li>
+                  <li class="soft--right"><a class="" href="https://find-a-buyer.export.great.gov.uk/" title="Find a buyer">Find a buyer</a></li>
+                  <li class="soft--right"><a class="" href="https://selling-online-overseas.export.great.gov.uk/" title="Selling online overseas">Selling online overseas</a></li>
                   <li><a class="" href="https://www.events.ukti.gov.uk/" title="Events">Events</a></li>
                 </ul>
               </div>
@@ -53,8 +53,8 @@
                         <h3 class="font-white">Our services:</h3>
                         <ul class="">
                           <li class="header-nav-link"><a class="font-reg" href="https://www.exportingisgreat.gov.uk/opportunities" title="Exporting opportunities">Exporting opportunities</a></li>
-                          <li class="header-nav-link"><a class="font-reg" href="http://find-a-buyer.export.great.gov.uk/" title="Find a buyer">Find a buyer</a></li>
-                          <li class="header-nav-link"><a class="font-reg" href="https://www.exportingisgreat.gov.uk/opportunities" title="Selling online overseas">Selling online overseas</a></li>
+                          <li class="header-nav-link"><a class="font-reg" href="https://find-a-buyer.export.great.gov.uk/" title="Find a buyer">Find a buyer</a></li>
+                          <li class="header-nav-link"><a class="font-reg" href="https://selling-online-overseas.export.great.gov.uk/" title="Selling online overseas">Selling online overseas</a></li>
                           <li class="header-nav-link"><a class="font-reg" href="https://www.events.ukti.gov.uk/" title="Events">Events</a></li>
                         </ul>
                       </nav>
@@ -96,9 +96,9 @@
                   <div class="footer-section">
                     <h3 class="footer-header">Our services</h3>
                     <ul>
-                      <li class="footer-links"><a href="https://selling-online-overseas.export.great.gov.uk/" title="Exporting opportunities">Exporting opportunities</a></li>
-                      <li class="footer-links"><a href="http://find-a-buyer.export.great.gov.uk/" title="Find a buyer">Find a buyer</a></li>
-                      <li class="footer-links"><a href="https://www.exportingisgreat.gov.uk/opportunities" title="Selling online overseas">Selling online overseas</a></li>
+                      <li class="footer-links"><a href="https://www.exportingisgreat.gov.uk/opportunities" title="Exporting opportunities">Exporting opportunities</a></li>
+                      <li class="footer-links"><a href="https://find-a-buyer.export.great.gov.uk/" title="Find a buyer">Find a buyer</a></li>
+                      <li class="footer-links"><a href="https://selling-online-overseas.export.great.gov.uk/" title="Selling online overseas">Selling online overseas</a></li>
                       <li class="footer-links"><a href="https://www.events.ukti.gov.uk/" title="Events">Events</a></li>
                     </ul>
                   </div>

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
                       <nav>
                         <h3 class="font-white push--top desktop-only">Exporting is GREAT:</h3>
                         <ul class="">
-                          <li class="header-nav-link"><a title="new to exporting" href="https://www.exportingisgreat.gov.uk/new/" class="active">NEW TO EXPORTING</a></li>
+                          <li class="header-nav-link"><a title="new to exporting" href="https://www.exportingisgreat.gov.uk/new/">NEW TO EXPORTING</a></li>
                           <li class="header-nav-link"><a title="occasional exporter" href="https://www.exportingisgreat.gov.uk/occasional/">OCCASIONAL EXPORTER</a></li>
                           <li class="header-nav-link"><a title="regular exporter" href="https://www.exportingisgreat.gov.uk/regular/">REGULAR EXPORTER</a></li>
                         </ul>


### PR DESCRIPTION
In several places the URLs in the HTML did not match their text.

Additionally, the "new to exporting" link was given a `class="active"` in order to demonstrate the correct styling of active links. However, this was applied as-is across the various implementations. As these links should only ever be active on the WordPress site, I've removed the styling here.