### PR TITLE
(fix) Update "Contact Us" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 ### Installation
     npm install
 
-
 ### Compile assets
     gulp
+
+### Notes
+
+You should substitute "SERVICE_NAME" part of the 'Contact us' link
+to the correct one for your particular service.

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
                       <li class="footer-links"><a href="https://www.exportingisgreat.gov.uk/occasional/" title="Occasional exporter">Occasional exporter</a></li>
                       <li class="footer-links"><a href="https://www.exportingisgreat.gov.uk/regular/" title="Regular exporter">Regular exporter</a></li>
                       <li class="footer-links"><a href="https://www.exportingisgreat.gov.uk/about/" title="About">About</a></li>
-                      <li class="footer-links"><a href="https://www.exportingisgreat.gov.uk/contact-us/" title="Contact us">Contact us</a></li>
+                      <li class="footer-links"><a href="https://contact-us.export.great.gov.uk/SERVICE_NAME" title="Contact us">Contact us</a></li>
                       <li class="footer-links"><a href="https://www.exportingisgreat.gov.uk/privacy-and-cookies/" title="Privacy and Cookies">Privacy &amp; cookies</a></li>
                       <li class="footer-links"><a href="https://www.exportingisgreat.gov.uk/terms-and-conditions/" title="Terms and conditions">Terms &amp; conditions</a></li>
                       <li class="footer-links"><a href="https://www.gov.uk/government/organisations/department-for-international-trade" title="Department for International Trade">Department for International Trade</a></li>


### PR DESCRIPTION
"Contact Us" should point to `https://contact-us.export.great.gov.uk/SERVICE_NAME`

e.g. `https://contact-us.export.great.gov.uk/export_ops` or `https://contact-us.export.great.gov.uk/selling_online_overseas`.