### PR TITLE
(fix) Update "Events" link

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
                   <li class="soft--right"><a class="" href="https://www.exportingisgreat.gov.uk/opportunities" title="Exporting opportunities">Exporting opportunities</a></li>
                   <li class="soft--right"><a class="" href="https://find-a-buyer.export.great.gov.uk/" title="Find a buyer">Find a buyer</a></li>
                   <li class="soft--right"><a class="" href="https://selling-online-overseas.export.great.gov.uk/" title="Selling online overseas">Selling online overseas</a></li>
-                  <li><a class="" href="https://www.events.ukti.gov.uk/" title="Events">Events</a></li>
+                  <li><a class="" href="https://events.trade.gov.uk/" title="Events">Events</a></li>
                 </ul>
               </div>
             </div>
@@ -55,7 +55,7 @@
                           <li class="header-nav-link"><a class="font-reg" href="https://www.exportingisgreat.gov.uk/opportunities" title="Exporting opportunities">Exporting opportunities</a></li>
                           <li class="header-nav-link"><a class="font-reg" href="https://find-a-buyer.export.great.gov.uk/" title="Find a buyer">Find a buyer</a></li>
                           <li class="header-nav-link"><a class="font-reg" href="https://selling-online-overseas.export.great.gov.uk/" title="Selling online overseas">Selling online overseas</a></li>
-                          <li class="header-nav-link"><a class="font-reg" href="https://www.events.ukti.gov.uk/" title="Events">Events</a></li>
+                          <li class="header-nav-link"><a class="font-reg" href="https://events.trade.gov.uk/" title="Events">Events</a></li>
                         </ul>
                       </nav>
                     </div>
@@ -99,7 +99,7 @@
                       <li class="footer-links"><a href="https://www.exportingisgreat.gov.uk/opportunities" title="Exporting opportunities">Exporting opportunities</a></li>
                       <li class="footer-links"><a href="https://find-a-buyer.export.great.gov.uk/" title="Find a buyer">Find a buyer</a></li>
                       <li class="footer-links"><a href="https://selling-online-overseas.export.great.gov.uk/" title="Selling online overseas">Selling online overseas</a></li>
-                      <li class="footer-links"><a href="https://www.events.ukti.gov.uk/" title="Events">Events</a></li>
+                      <li class="footer-links"><a href="https://events.trade.gov.uk/" title="Events">Events</a></li>
                     </ul>
                   </div>
                 </div>


### PR DESCRIPTION
The events link has changed to https://events.trade.gov.uk/.